### PR TITLE
Implement sizing of multipart uploads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
   - Make [chrono] an optional dependency, as it was only used by the
     `cloudwatch` mode.
+  - Implement sizing of in-progress multipart uploads. Although they aren't
+    really object verisons, the `--object-versions` arguments `all` and
+    `multipart` account for the size of these incomplete objects.
 
 # v1.0.1
 

--- a/README.md
+++ b/README.md
@@ -191,12 +191,15 @@ call, 1 API call per listed bucket to `GetBucketLocation` to discover its
 region, 1 API call per listed bucket to `HeadBucket` to make sure we have
 access to list the objects, and:
 
+  - at least 1 call to `ListMultipartUploads`, at least 1 call to
+    `ListObjectVersions`, and at least 1 call to `ListParts` if in-progress
+    multipart uploads are found in the `All` object mode
   - at least 1 call to `ListObjectsV2` per-bucket in the `Current` object
     (default) mode
   - at least 1 call to `ListObjectVersions` per bucket in the `NonCurrent`
     object mode
   - at least 1 call to `ListMultipartUploads` per-bucket in the `Multipart`
-    mode with at least 1 call to `ListPart` if any in-progress multipart
+    mode with at least 1 call to `ListParts` if any in-progress multipart
     uploads are found
 
 Each of the API calls listed above will return 1,000 objects maximum, if your

--- a/README.md
+++ b/README.md
@@ -75,10 +75,11 @@ versions. Command line flags (or environment variables) can be used to change
 how the S3 mode operates. With these you can change the S3 mode to operate in
 one of 3 ways:
 
-  - All: Show bucket size as the sum of all current object versions + all
-    non-current object versions.
+  - All: Show bucket size as the sum of all modes listed below.
   - Current: Show bucket size as the sum of all current object versions, this
     is the default.
+  - Multipart: Show bucket size as the sum of all in-progress multipart
+    uploads.
   - NonCurrent: Show bucket size as the sum of all non-current object versions.
 
 These can be selected via the `--object-versions` CLI flag if `s3du` was
@@ -188,18 +189,25 @@ AWS S3 is a more expensive, but more accurate, method of listing bucket sizes.
 The S3 mode of `s3du` will use 1 API call to perform the `ListBuckets` API
 call, 1 API call per listed bucket to `GetBucketLocation` to discover its
 region, 1 API call per listed bucket to `HeadBucket` to make sure we have
-access to list the objects, and at least 1 call to either `ListObjectsV2` or
-`ListObjectVersions` per bucket.
+access to list the objects, and:
 
-The `ListObjectsV2` and `ListObjectVersions` API calls will each return 1,000
-objects maximum, if your bucket has more objects than this, pagination will be
-required.
+  - at least 1 call to `ListObjectsV2` per-bucket in the `Current` object
+    (default) mode
+  - at least 1 call to `ListObjectVersions` per bucket in the `NonCurrent`
+    object mode
+  - at least 1 call to `ListMultipartUploads` per-bucket in the `Multipart`
+    mode with at least 1 call to `ListPart` if any in-progress multipart
+    uploads are found
 
-For example, let's say we're running in S3 mode getting the sizes of current
+Each of the API calls listed above will return 1,000 objects maximum, if your
+bucket has more objects than this, pagination will be required.
+
+For example, let's say we're running in S3 mode getting the sizes of `current`
 object versions and our AWS account has 2 buckets.
 `bucket-a` (no versioning enabled) has 10,000 objects and `bucket-b`
 (versioning enabled) has 32,768 object versions of which 13,720 are current
-versions and 19,048 are non-current versions. This would mean:
+versions and 19,048 are non-current versions. There is also an in-progress
+multipart upload with 2 parts uploaded in `bucket-a`. This would mean:
 
   - 1 API call to `ListBuckets` for bucket discovery
   - 2 API calls to `GetBucketLocation` for region discovery, 1 for each bucket
@@ -210,18 +218,21 @@ versions and 19,048 are non-current versions. This would mean:
 for a total of 29 API calls.
 
 If we were to run `s3du` against the same account a second time, but ask for
-the sum of all object versions, we'd get the following:
+the sum of `all` object versions, we'd get the following:
 
   - 1 API call to `ListBuckets` for bucket discovery
   - 2 API calls to `GetBucketLocation` for region discovery, 1 for each bucket
   - 2 API calls to `HeadBucket` to check we have access, 1 for each bucket
   - 10 API calls to `ListObjectVersions` for `bucket-a`
   - 33 API calls to `ListObjectVersions` for `bucket-b`
+  - 1 API call to `ListMultipartUploads` for `bucket-a`
+  - 1 API call to `ListMultipartUploads` for `bucket-b`
+  - 1 API call to `ListParts` for `bucket-a`
 
-for a total of 48 API calls.
+for a total of 51 API calls.
 
 A third run of `s3du` against the same account but asking for the sum of
-non-current object versions would result in the following:
+`non-current` object versions would result in the following:
 
   - 1 API call to `ListBuckets` for bucket discovery
   - 2 API calls to `GetBucketLocation` for region discovery, 1 for each bucket
@@ -231,11 +242,11 @@ non-current object versions would result in the following:
 
 for a total of 39 API calls.
 
-You will notice that the number of API calls for `bucket-b` are the same across
-both the "all" and "non-current" object versions requests, this is because any
-filtering for current vs. non-current objects in these scenarios must be done
-by `s3du`. The `ListObjectVersions` API does not let us specify which object
-versions we'd like to retrieve.
+You will notice that the number of API calls to `ListObjectVersions` for
+`bucket-b` are the same across both the `all` and `non-current` object versions
+requests, this is because any filtering for current vs. non-current objects in
+these scenarios must be done by `s3du`. The `ListObjectVersions` API does not
+let us specify which object versions we'd like to retrieve.
 
 <!-- links -->
 [`aws-vault`]: https://github.com/99designs/aws-vault/

--- a/man/s3du.1
+++ b/man/s3du.1
@@ -52,6 +52,7 @@ mode.
 Possible values are:
 .Dq Cm all ,
 .Dq Cm current ,
+.Dq Cm multipart ,
 and
 .Dq Cm non-current .
 This flag will only be present if
@@ -150,6 +151,14 @@ pandemic.
 .Nm
 was developed by
 .An David O'Rourke .
+.Sh CAVEATS
+While in-progress
+.Ar multipart
+uploads are not technically
+.Dq object versions ,
+selecting them for sizing is still covered under the
+.Fl Fl object-versions
+option as it is the most logical way to perform that operation.
 .Sh BUGS
 Please report bugs, issues, and feature requests to
 .Lk https://github.com/phyber/s3du/issues

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -61,6 +61,7 @@ const VALID_SIZE_UNITS: &[&str] = &[
 const OBJECT_VERSIONS: &[&str] = &[
     "all",
     "current",
+    "multipart",
     "non-current",
 ];
 

--- a/src/common/object_versions.rs
+++ b/src/common/object_versions.rs
@@ -14,6 +14,9 @@ pub enum ObjectVersions {
     /// Sum only size of current objects
     Current,
 
+    /// Sum only size of in-progress multipart uploads
+    Multipart,
+
     /// Sum only size of non-current objects
     NonCurrent,
 }
@@ -27,6 +30,7 @@ impl FromStr for ObjectVersions {
         match s {
             "all"         => Ok(Self::All),
             "current"     => Ok(Self::Current),
+            "multipart"   => Ok(Self::Multipart),
             "non-current" => Ok(Self::NonCurrent),
             _             => Err("no match"),
         }

--- a/src/s3/client.rs
+++ b/src/s3/client.rs
@@ -287,7 +287,12 @@ impl Client {
 
         match self.object_versions {
             ObjectVersions::All => {
-                self.size_object_versions(bucket).await
+                let mut size = 0;
+
+                size += self.size_multipart_uploads(bucket).await?;
+                size += self.size_object_versions(bucket).await?;
+
+                Ok(size)
             },
             ObjectVersions::Current => {
                 self.size_current_objects(bucket).await
@@ -491,6 +496,15 @@ mod tests {
         ];
 
         assert_eq!(ret, expected);
+    }
+
+    // This test is currently ignored as we cannot easily mock multiple
+    // requests at the moment. Issues #1671 and PR #1685 should solve this.
+    // Requires responses for both ListMultipartUploads and ListParts
+    #[ignore]
+    #[tokio::test]
+    async fn test_size_multipart_uploads() {
+        todo!()
     }
 
     #[tokio::test]

--- a/src/s3/client.rs
+++ b/src/s3/client.rs
@@ -546,10 +546,12 @@ mod tests {
         let ret = Client::size_parts(
             &client,
             "test-bucket",
-            "foo.txt",
+            "test.zip",
             "abc123",
-            ).await;
+        ).await.unwrap();
 
-        assert!(ret.is_ok());
+        let expected = 1024 * 100 * 2;
+
+        assert_eq!(ret, expected);
     }
 }

--- a/src/s3/client.rs
+++ b/src/s3/client.rs
@@ -207,7 +207,7 @@ impl Client {
                                     None
                                 }
                             },
-                            ObjectVersions::Multipart => unimplemented!(),
+                            ObjectVersions::Multipart => unreachable!(),
                             ObjectVersions::NonCurrent => {
                                 if is_latest {
                                     None

--- a/test-data/s3-list-parts.xml
+++ b/test-data/s3-list-parts.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ListPartsResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+    <Bucket>test-bucket</Bucket>
+    <Key>test.zip</Key>
+    <UploadId>abc123</UploadId>
+    <Initiator>
+        <ID>arn:aws:iam::123456789012:user/test</ID>
+        <DisplayName>test</DisplayName>
+    </Initiator>
+    <Owner>
+        <ID>f2ca1bb6c7e907d06dafe4687e579fce76b37e4e93b7605022da52e6ccc26fd2</ID>
+        <DisplayName>test</DisplayName>
+    </Owner>
+    <StorageClass>STANDARD</StorageClass>
+    <PartNumberMarker>0</PartNumberMarker>
+    <NextPartNumberMarker>2</NextPartNumberMarker>
+    <MaxParts>1000</MaxParts>
+    <IsTruncated>false</IsTruncated>
+    <Part>
+        <PartNumber>1</PartNumber>
+        <LastModified>2015-09-08T21:02:04.000Z</LastModified>
+        <ETag>&quot;b026324c6904b2a9cb4b88d6d61c81d1&quot;</ETag>
+        <Size>102400</Size>
+    </Part>
+    <Part>
+        <PartNumber>2</PartNumber>
+        <LastModified>2015-09-08T21:02:09.000Z</LastModified>
+        <ETag>&quot;26ab0db90d72e28ad0ba1e22ee510510&quot;</ETag>
+        <Size>102400</Size>
+    </Part>
+</ListPartsResult>


### PR DESCRIPTION
Fixes #1 

This PR implements the sizing of multipart uploads, used by selecting `--object-versions=multipart` or `--object-versions=all`.

A test for the `size_parts` method is included and an ignored test is added for the `size_multipart_uploads` method, ready for when more complex testing is added to `rusoto_mock`.